### PR TITLE
Proofreading corrections for e-stat01-eda

### DIFF
--- a/exercises/e-stat01-eda-master.ipynb
+++ b/exercises/e-stat01-eda-master.ipynb
@@ -248,10 +248,10 @@
     "- What variables does this dataset have?\n",
     "  - (Your response here)\n",
     "<!-- task-end -->\n",
-    "<!-- task-begin -->\n",
+    "<!-- solution-begin -->\n",
     "- What variables does this dataset have?\n",
     "  - `carat`, `cut`, `color`, `clarity`, `depth`, `table`, `price`, `x`, `y`, `z`\n",
-    "<!-- task-end -->"
+    "<!-- solution-end -->"
    ]
   },
   {
@@ -443,7 +443,7 @@
     "- What is a typical value for the `price` of a diamond, according to this dataset?\n",
     "  - A typical price is around `3000`. The mean price is `3932.80` and the median price is `2401`.\n",
     "- What is the largest diamond in the dataset? (According to `carat`.) What is the smallest?\n",
-    "  - The largest carat is `0.2` and the smallest carat is `5.01`.\n",
+    "  - The smallest carat is `0.2` and the largest carat is `5.01`.\n",
     "- You identified all the variables in the dataset in __q1__ above. Do the results from `gr.tf_describe()` provide information on **all** of these variables?\n",
     "  - No: we do not see results for `cut`, `color`, or `clarity`.\n",
     "<!-- solution-end -->\n"
@@ -467,7 +467,7 @@
     ")\n",
     "```\n",
     "\n",
-    "> *Aside*: A categorical variable is sometimes called a *factor*. The unique values of a categorical variable are called *levels*.\n",
+    "*Aside*: A categorical variable is sometimes called a *factor*. The unique values of a categorical variable are called *levels*.\n",
     "\n",
     "We can use `gr.tf_distinct()` to figure out what values show up for a categorical variable.\n"
    ]
@@ -736,7 +736,7 @@
     "\n",
     "I'm going to walk you through a train of thought I had when studying the diamonds dataset.\n",
     "\n",
-    "There are four standard \"C's\" of [judging](https://en.wikipedia.org/wiki/Diamond_(gemstone)) a diamond. These are `carat, cut, color` and `clarity`, all of which are in the `diamonds` dataset."
+    "There are four standard \"C's\" of [judging](https://en.wikipedia.org/wiki/Diamond_(gemstone)) a diamond. These are `carat, cut, color` and `clarity`, all of which are in the `df_diamonds` dataset."
    ]
   },
   {
@@ -947,7 +947,6 @@
     "# NOTE: No need to edit; run and inspect\n",
     "(\n",
     "    df_diamonds\n",
-    "    \n",
     "    >> gr.ggplot(gr.aes(\"cut\", \"price\"))\n",
     "    + gr.geom_boxplot()\n",
     ")\n"


### PR DESCRIPTION
## Change Log

-  **q1** Observation answers still shown replaced in correct ‘task-begin/end’ indicators with ‘solution-begin/end’
- **q2** Observations corrected from “The **largest** carat is `0.2` and the **smallest** carat is `5.01`" to be “The **smallest** carat is `0.2` and the **largest** carat is `5.01.`”
- Deleted block quote to maintain style estaablished in other exercises (see e-data01)
- Under ‘Guided EDA,’ altered reference to “`diamonds` dataset” to “`df_diamonds` dataset” to keep consistency with q1 and **q3**
- **q7** deleted new line in code chunk for consistency
