### PR TITLE
Proofreading corrections: e-data01-isolate

### DIFF
--- a/exercises/e-data01-isolate-master.ipynb
+++ b/exercises/e-data01-isolate-master.ipynb
@@ -3800,7 +3800,7 @@
     "(\n",
     "    df_flights\n",
     "# solution-begin\n",
-    "    >> gr.tf_filter(DF[\"dep_delay\"] < 0)\n",
+    "    >> gr.tf_filter(df_flights[\"dep_delay\"] < 0)\n",
     "# solution-end\n",
     ")"
    ]


### PR DESCRIPTION
## Change Log
- q6 solution uses DF before it’s introduced
-  Replaced argument `DF["dep_delay"]` to be `df_flights["dep_delay"]` to match order of content introduction